### PR TITLE
Add better support for using OpenAI subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ To better understand skUnit, Check these documents:
 
 ## Requirements
 - .NET 7.0 or higher
-- An OpenAI API key
+- An OpenAI API key or an AzureOpenAI API key
 
 ## Installation
 You can easily add **skUnit** to your project as it is available as a [NuGet](https://www.nuget.org/packages/skUnit) package. To install it, execute the following command in your terminal:
@@ -137,14 +137,18 @@ You can easily add **skUnit** to your project as it is available as a [NuGet](ht
 dotnet add package skUnit
 ```
 
-Afterwards, you'll need to instantiate the `SemanticKernelAssert` class in your test constructor. This requires passing your OpenAI subscription details as parameters:
+Afterwards, you'll need to instantiate the `SemanticKernelAssert` class in your test constructor. This requires passing your OpenAI or AzureOpenAI subscription details as parameters:
 ```csharp
 public class MyTest
 {
   SemanticKernelAssert SemanticKernelAssert { get; set; }
   MyTest(ITestOutputHelper output)
   {
+    // For AzureOpenAI
     SemanticKernelAssert = new SemanticKernelAssert(_deploymentName, _endpoint, _apiKey, message => output.WriteLine(message));
+    
+    // For OpenAI
+    SemanticKernelAssert = new SemanticKernelAssert(_apiKey, message => output.WriteLine(message));
   }
 
   [Fact]

--- a/src/skUnit.Tests/SemanticAssertTests/SemanticAssertTests.cs
+++ b/src/skUnit.Tests/SemanticAssertTests/SemanticAssertTests.cs
@@ -25,6 +25,31 @@ namespace skUnit.Tests.SemanticAssertTests
             SemanticAssert = new SemanticAssert(deploymentName, endpoint, apiKey);
         }
 
+        public SemanticAssertTests(ITestOutputHelper output, bool useOpenAI)
+        {
+            Output = output;
+
+            var apiKey =
+                Environment.GetEnvironmentVariable("openai-api-key", EnvironmentVariableTarget.User) ??
+                throw new Exception("No ApiKey in environment variables.");
+
+            if (useOpenAI)
+            {
+                SemanticAssert = new SemanticAssert(apiKey);
+            }
+            else
+            {
+                var endpoint =
+                    Environment.GetEnvironmentVariable("openai-endpoint", EnvironmentVariableTarget.User) ??
+                    throw new Exception("No Endpoint in environment variables.");
+                var deploymentName =
+                    Environment.GetEnvironmentVariable("openai-deployment-name", EnvironmentVariableTarget.User) ??
+                    throw new Exception("No DeploymentName in environment variables.");
+
+                SemanticAssert = new SemanticAssert(deploymentName, endpoint, apiKey);
+            }
+        }
+
         [Theory]
         [MemberData(nameof(GetSimilarData))]
         public void Similar_True_MustWork(string first, string second)

--- a/src/skUnit/Asserts/SemanticAssert.cs
+++ b/src/skUnit/Asserts/SemanticAssert.cs
@@ -42,6 +42,18 @@ namespace skUnit
         }
 
         /// <summary>
+        /// This class needs a SemanticKernel kernel to work.
+        /// Using this constructor you can use an OpenAI subscription to configure it.
+        /// </summary>
+        /// <param name="apiKey"></param>
+        public SemanticAssert(string apiKey)
+        {
+            var kernel = Kernel.Builder.Build();
+            kernel.Config.AddOpenAITextCompletionService("text-davinci-003", apiKey);
+            Semantic = new Semantic(kernel);
+        }
+
+        /// <summary>
         /// Checks whether <paramref name="first"/> and <paramref name="second"/> string are semantically similar.
         /// It uses the kernel and OpenAI to check this semantically.
         /// <example>

--- a/src/skUnit/Asserts/SemanticKernelAssert_Initialize.cs
+++ b/src/skUnit/Asserts/SemanticKernelAssert_Initialize.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -53,6 +53,27 @@ namespace skUnit
             Semantic = new Semantic(kernel);
             OnLog = onLog;
 
+        }
+
+        /// <summary>
+        /// This class needs a SemanticKernel kernel to work.
+        /// Using this constructor you can use an OpenAI subscription to configure it.
+        /// </summary>
+        /// <param name="apiKey"></param>
+        /// <param name="onLog">If you're using xUnit, do this in the constructor:
+        /// <code>
+        /// MyTest(ITestOutputHelper output)
+        /// {
+        ///    SemanticKernelAssert = new SemanticKernelAssert(_apiKey, output.WriteLine);
+        /// }
+        /// </code>
+        /// </param>
+        public SemanticKernelAssert(string apiKey, Action<string> onLog)
+        {
+            var kernel = Kernel.Builder.Build();
+            kernel.Config.AddOpenAITextCompletionService("text-davinci-003", apiKey);
+            Semantic = new Semantic(kernel);
+            OnLog = onLog;
         }
 
         private void Log(string? message = "")


### PR DESCRIPTION
Fixes #2

Add support for configuring OpenAI subscriptions directly.

* **README.md**:
  - Add instructions for configuring OpenAI subscriptions.
  - Update example code to include OpenAI configuration.
* **src/skUnit/Asserts/SemanticAssert.cs**:
  - Add a new constructor to accept OpenAI API key directly.
* **src/skUnit/Asserts/SemanticKernelAssert_Initialize.cs**:
  - Add a new constructor to accept OpenAI API key directly.
* **src/skUnit.Tests/SemanticAssertTests/SemanticAssertTests.cs**:
  - Add tests for the new OpenAI constructor.
  - Update existing tests to include OpenAI configuration.

