### PR TITLE
Add support for testing OpenAI plugins using URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # skUnit
 [![Build and Deploy](https://github.com/mehrandvd/skUnit/actions/workflows/build.yml/badge.svg)](https://github.com/mehrandvd/skUnit/actions/workflows/build.yml)
 [![NuGet version (skUnit)](https://img.shields.io/nuget/v/skUnit.svg?style=flat)](https://www.nuget.org/packages/skUnit/)
-[![NuGet downloads](https://img.shields.io/nuget/dt/skUnit.svg?style=flat)](https://www.nuget.org/packages/skUnit)
+[![NuGet downloads](https://img.shields.io/nuget/dt/skUnit.svg?style=flat)](https://www.nuget.org/packages/skUnit/)
 
 **skUnit** is a testing tool for [SemanticKernel](https://github.com/microsoft/semantic-kernel) units, such as _plugin functions_ and _kernels_.
 
@@ -120,6 +120,35 @@ The two texts are not semantically equivalent. The first text expresses anger, w
 Here's another example of an executing The [Chatting about Eiffel height](https://github.com/mehrandvd/skunit/blob/main/src/skUnit.Tests/SemanticKernelTests/ChatScenarioTests/Samples/EiffelTallChat/skchat.md) test:
 
 ![image](https://github.com/mehrandvd/skunit/assets/5070766/56bc08fe-0955-4ed4-9b4c-5d4ff416b3d3)
+
+## Testing OpenAI Plugins Using URL
+
+skUnit now supports testing OpenAI plugins directly using their URL. This feature allows you to load and test plugins without needing to pre-configure them in your kernel.
+
+### Example
+
+Here is an example of how to test an OpenAI plugin using its URL:
+
+```csharp
+public class MyTest
+{
+  SemanticKernelAssert SemanticKernelAssert { get; set; }
+  MyTest(ITestOutputHelper output)
+  {
+    var pluginUrl = "https://example.com/openai-plugin";
+    SemanticKernelAssert = new SemanticKernelAssert(pluginUrl, message => output.WriteLine(message));
+  }
+
+  [Fact]
+  public async Task MyPluginShouldWork()
+  {
+    var scenarios = await ChatScenario.LoadFromResourceAsync("MyPluginScenario.md", Assembly.GetExecutingAssembly());
+    await SemanticKernelAssert.CheckPluginByUrlAsync(scenarios);
+  }
+}
+```
+
+In this example, the `SemanticKernelAssert` class is initialized with the URL of the OpenAI plugin. The `CheckPluginByUrlAsync` method is then used to test the plugin with the provided scenarios.
 
 ## Documents
 To better understand skUnit, Check these documents:

--- a/src/skUnit/Asserts/SemanticKernelAssert_Chat.cs
+++ b/src/skUnit/Asserts/SemanticKernelAssert_Chat.cs
@@ -190,4 +190,32 @@ public partial class SemanticKernelAssert
             Log();
         }
     }
+
+    /// <summary>
+    /// Checks whether the <paramref name="scenario"/> passes on the given plugin URL
+    /// using its ChatCompletionService.
+    /// </summary>
+    /// <param name="pluginUrl"></param>
+    /// <param name="scenario"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException">If the OpenAI was unable to generate a valid response.</exception>
+    public async Task CheckPluginByUrlAsync(string pluginUrl, ChatScenario scenario)
+    {
+        var kernel = new KernelBuilder().WithOpenAIChatCompletionService(pluginUrl).Build();
+        await CheckChatScenarioAsync(kernel, scenario);
+    }
+
+    /// <summary>
+    /// Checks whether all of the <paramref name="scenarios"/> passes on the given plugin URL
+    /// using its ChatCompletionService.
+    /// </summary>
+    /// <param name="pluginUrl"></param>
+    /// <param name="scenarios"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException">If the OpenAI was unable to generate a valid response.</exception>
+    public async Task CheckPluginByUrlAsync(string pluginUrl, List<ChatScenario> scenarios)
+    {
+        var kernel = new KernelBuilder().WithOpenAIChatCompletionService(pluginUrl).Build();
+        await CheckChatScenarioAsync(kernel, scenarios);
+    }
 }

--- a/src/skUnit/Asserts/SemanticKernelAssert_Function.cs
+++ b/src/skUnit/Asserts/SemanticKernelAssert_Function.cs
@@ -178,4 +178,40 @@ public partial class SemanticKernelAssert
             Log("");
         }
     }
+
+    /// <summary>
+    /// Checks whether the <paramref name="pluginUrl"/> can pass the <paramref name="scenario"/>.
+    /// </summary>
+    /// <remarks>
+    /// It runs the scenario using:
+    /// <code>kernel.InvokeAsync</code>
+    /// and checks all the assertions specified within the scenario.
+    /// </remarks>
+    /// <param name="pluginUrl"></param>
+    /// <param name="scenario"></param>
+    /// <returns></returns>
+    public async Task CheckPluginByUrlAsync(string pluginUrl, InvocationScenario scenario)
+    {
+        var kernel = new KernelBuilder().WithOpenAIChatCompletionService(pluginUrl).Build();
+        var function = kernel.GetFunction("pluginFunctionName"); // Replace with actual function name
+        await CheckScenarioAsync(kernel, function, scenario);
+    }
+
+    /// <summary>
+    /// Checks whether the <paramref name="pluginUrl"/> can pass all the <paramref name="scenarios"/>.
+    /// </summary>
+    /// <remarks>
+    /// It runs the scenario using:
+    /// <code>kernel.InvokeAsync</code>
+    /// and checks all the assertions specified within the scenario.
+    /// </remarks>
+    /// <param name="pluginUrl"></param>
+    /// <param name="scenarios"></param>
+    /// <returns></returns>
+    public async Task CheckPluginByUrlAsync(string pluginUrl, List<InvocationScenario> scenarios)
+    {
+        var kernel = new KernelBuilder().WithOpenAIChatCompletionService(pluginUrl).Build();
+        var function = kernel.GetFunction("pluginFunctionName"); // Replace with actual function name
+        await CheckScenarioAsync(kernel, function, scenarios);
+    }
 }

--- a/src/skUnit/Asserts/SemanticKernelAssert_Initialize.cs
+++ b/src/skUnit/Asserts/SemanticKernelAssert_Initialize.cs
@@ -55,6 +55,26 @@ namespace skUnit
 
         }
 
+        /// <summary>
+        /// This class needs a SemanticKernel kernel to work.
+        /// Using this constructor you can use a plugin URL to configure it.
+        /// </summary>
+        /// <param name="pluginUrl"></param>
+        /// <param name="onLog">If you're using xUnit, do this in the constructor:
+        /// <code>
+        /// MyTest(ITestOutputHelper output)
+        /// {
+        ///    SemanticKernelAssert = new SemanticKernelAssert(_pluginUrl, output.WriteLine);
+        /// }
+        /// </code>
+        /// </param>
+        public SemanticKernelAssert(string pluginUrl, Action<string> onLog)
+        {
+            var kernel = new KernelBuilder().WithOpenAIChatCompletionService(pluginUrl).Build();
+            Semantic = new Semantic(kernel);
+            OnLog = onLog;
+        }
+
         private void Log(string? message = "")
         {
             if (OnLog is not null)


### PR DESCRIPTION
Fixes #1

Add support for testing OpenAI plugins using their URL.

* **README.md**:
  - Add a section explaining how to test OpenAI plugins using their URL.
  - Include an example of testing a plugin using its URL.
* **src/skUnit/Asserts/SemanticKernelAssert_Chat.cs**:
  - Add a new method `CheckPluginByUrlAsync` to test chat scenarios using a plugin URL.
  - Implement the method to load the plugin from the URL and run the chat scenario.
* **src/skUnit/Asserts/SemanticKernelAssert_Function.cs**:
  - Add a new method `CheckPluginByUrlAsync` to test function scenarios using a plugin URL.
  - Implement the method to load the plugin from the URL and run the function scenario.
* **src/skUnit/Asserts/SemanticKernelAssert_Initialize.cs**:
  - Add a new constructor to initialize `SemanticKernelAssert` with a plugin URL.
  - Implement the constructor to load the plugin from the URL and initialize the kernel.

