### PR TITLE
Upgrade to MEAI 9.7.1

### DIFF
--- a/src/skUnit.Tests/ScenarioAssertTests/McpTests.cs
+++ b/src/skUnit.Tests/ScenarioAssertTests/McpTests.cs
@@ -2,7 +2,6 @@
 using skUnit.Tests.Infrastructure;
 using System.ComponentModel;
 using ModelContextProtocol.Client;
-using ModelContextProtocol.Protocol.Transport;
 using Xunit.Abstractions;
 using Microsoft.Extensions.Configuration;
 

--- a/src/skUnit.Tests/skUnit.Tests.csproj
+++ b/src/skUnit.Tests/skUnit.Tests.csproj
@@ -19,16 +19,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.2.0-beta.4" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.3.0-beta.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.50.0" />
-    <PackageReference Include="ModelContextProtocol" Version="0.1.0-preview.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.61.0" />
+    <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/skUnit/skUnit.csproj
+++ b/src/skUnit/skUnit.csproj
@@ -15,10 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.40.0" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="9.4.4-preview.1.25259.16" />
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.46.0" />
-    <PackageReference Include="SemanticValidation" Version="0.19.0-beta" />
+    <PackageReference Include="Markdig" Version="0.41.3" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="9.7.1" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.61.0" />
+    <PackageReference Include="SemanticValidation" Version="0.22.0-beta" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Removed `ModelContextProtocol.Protocol.Transport` import and added `Microsoft.Extensions.AI` in `McpTests.cs`.
- Updated package versions in `skUnit.Tests.csproj`:
  - `Azure.AI.OpenAI` to `2.3.0-beta.1`
  - `Microsoft.NET.Test.Sdk` to `17.14.1`
  - `Microsoft.SemanticKernel` to `1.61.0`
  - `ModelContextProtocol` to `0.3.0-preview.3`
  - `xunit.runner.visualstudio` to `3.1.3`
- Updated package versions in `skUnit.csproj`:
  - `Markdig` to `0.41.3`
  - `Microsoft.Extensions.AI` to `9.7.1`
  - `Microsoft.SemanticKernel.Abstractions` to `1.61.0`
  - `SemanticValidation` to `0.22.0-beta`