### PR TITLE
Remove SemanticKernel.Abstractions package reference

### DIFF
--- a/src/skUnit/skUnit.csproj
+++ b/src/skUnit/skUnit.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Microsoft.Agents.AI" Version="1.10.0" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.77.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The Microsoft.SemanticKernel.Abstractions dependency (v1.77.0) was removed from skUnit.csproj. This change reduces unnecessary dependencies and may help streamline package management.