### PR TITLE
Update to .NET 10, modernize OpenAI and test dependencies

### DIFF
--- a/src/skUnit.Tests/Infrastructure/SemanticTestBase.cs
+++ b/src/skUnit.Tests/Infrastructure/SemanticTestBase.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using Azure;
 using Azure.AI.OpenAI;
 using Markdig.Helpers;
 using Microsoft.Extensions.AI;
@@ -7,7 +8,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using skUnit.Scenarios;
 using skUnit.Scenarios.Parsers;
-using Xunit.Abstractions;
 
 namespace skUnit.Tests.Infrastructure;
 
@@ -45,7 +45,7 @@ public class SemanticTestBase
         // Create assertion client for semantic evaluations
         var assertionClient = new AzureOpenAIClient(
             new Uri(Endpoint),
-            new System.ClientModel.ApiKeyCredential(ApiKey)
+            new AzureKeyCredential(ApiKey)
             ).GetChatClient(DeploymentName).AsIChatClient();
 
         ScenarioRunner = new ChatScenarioRunner(assertionClient, message => Output.WriteLine(message));
@@ -55,7 +55,7 @@ public class SemanticTestBase
         // Create system under test client
         var openAI = new AzureOpenAIClient(
             new Uri(Endpoint),
-            new System.ClientModel.ApiKeyCredential(ApiKey)
+            new AzureKeyCredential(ApiKey)
         ).GetChatClient(DeploymentName).AsIChatClient();
 
         BaseChatClient = new ChatClientBuilder(openAI)

--- a/src/skUnit.Tests/RunnerTests/ChatScenarioRunnerTests.cs
+++ b/src/skUnit.Tests/RunnerTests/ChatScenarioRunnerTests.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.AI;
 using skUnit.Exceptions;
 using skUnit.Tests.Infrastructure;
-using Xunit.Abstractions;
 
 namespace skUnit.Tests.RunnerTests
 {

--- a/src/skUnit.Tests/RunnerTests/HallucinationChatClientTests.cs
+++ b/src/skUnit.Tests/RunnerTests/HallucinationChatClientTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.ComponentModel;
 using Microsoft.Extensions.AI;
 using skUnit.Tests.Infrastructure;
-using Xunit.Abstractions;
 
 namespace skUnit.Tests.RunnerTests
 {

--- a/src/skUnit.Tests/SemanticAssertTests/SemanticAssertTests.cs
+++ b/src/skUnit.Tests/SemanticAssertTests/SemanticAssertTests.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
 using skUnit.Exceptions;
 using skUnit.Tests.Infrastructure;
-using Xunit.Abstractions;
 
 namespace skUnit.Tests.SemanticAssertTests
 {

--- a/src/skUnit.Tests/skUnit.Tests.csproj
+++ b/src/skUnit.Tests/skUnit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -20,22 +20,25 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.67.1" />
-    <PackageReference Include="ModelContextProtocol" Version="0.4.0-preview.3" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.9.0-beta.1" />
+    <PackageReference Include="Microsoft.Agents.AI" Version="1.10.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0-pre.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/skUnit/skUnit.csproj
+++ b/src/skUnit/skUnit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Title>skUnit</Title>


### PR DESCRIPTION
Upgraded projects to .NET 10.0. Updated and replaced test dependencies: removed Microsoft.SemanticKernel, added Microsoft.Agents.AI and Microsoft.Extensions.AI.OpenAI, and bumped xUnit and coverlet versions. Switched to AzureKeyCredential for OpenAI client. Cleaned up unused usings and test infrastructure.