### PR TITLE
Make SetDefaultLogger static in ChatScenarioRunner

### DIFF
--- a/src/skUnit/Runners/ChatScenarioRunner.cs
+++ b/src/skUnit/Runners/ChatScenarioRunner.cs
@@ -77,7 +77,7 @@ namespace skUnit
         /// Sets the default logger for all instances of ChatScenarioRunner that do not have a specific logger provided.
         /// </summary>
         /// <param name="logger">The logger to set as the default</param>
-        public void SetDefaultLogger(ILogger logger)
+        public static void SetDefaultLogger(ILogger logger)
         {
             DefaultLogger = logger;
         }


### PR DESCRIPTION
Changed SetDefaultLogger from an instance method to a static method in the ChatScenarioRunner class. This allows setting the default logger without requiring an instance of the class.